### PR TITLE
Reviewdog linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,8 @@ jobs:
       run: yarn install --frozen-lockfile
 
     - name: Run linting
-      run: yarn lint
+      uses: reviewdog/action-eslint@v1
+      with:
+        level: error
+        filter_mode: file
+        fail_on_error: true


### PR DESCRIPTION
Replaced default (boring) `yarn lint` with reviewdog.